### PR TITLE
Feature/stable output

### DIFF
--- a/block_constraint.go
+++ b/block_constraint.go
@@ -125,8 +125,10 @@ func (bc BlockConstraint) Matches(b *newsdoc.Block) (Match, []string) {
 		return NoMatch, nil
 	}
 
-	for k, check := range bc.Match {
+	for _, k := range bc.Match.Keys {
 		value, ok := blockMatchAttribute(b, k)
+
+		check := bc.Match.Constraints[k]
 
 		// Optional attributes are empty strings.
 		check.AllowEmpty = check.AllowEmpty || check.Optional
@@ -285,7 +287,7 @@ func (bc BlockConstraint) DescribeCountConstraint(kind BlockKind) string {
 		)
 	}
 
-	if len(bc.Match) > 0 {
+	if len(bc.Match.Keys) > 0 {
 		s.WriteString(" where ")
 		s.WriteString(bc.Match.Requirements())
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -120,6 +120,8 @@ func testCollectionAgainstGolden(
 			data, err := json.MarshalIndent(collected, "", "  ")
 			must(t, err, "marshal for golden reference file")
 
+			data = append(data, '\n')
+
 			err = os.WriteFile(goldenPath, data, 0o600)
 			must(t, err, "write golden reference file")
 		}

--- a/document_constraint.go
+++ b/document_constraint.go
@@ -47,11 +47,13 @@ func (dc DocumentConstraint) Matches(
 		return NoMatch
 	}
 
-	for k, check := range dc.Match {
+	for _, k := range dc.Match.Keys {
 		value, ok := documentMatchAttribute(d, k)
 		if !ok {
 			return NoMatch
 		}
+
+		check := dc.Match.Constraints[k]
 
 		_, err := check.Validate(value, ok, vCtx)
 		if err != nil {

--- a/enum.go
+++ b/enum.go
@@ -3,6 +3,7 @@ package revisor
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -51,6 +52,8 @@ func mergedEnumAllowedValues(m *mergedEnum) []string {
 			vals = append(vals, s)
 		}
 	}
+
+	slices.Sort(vals)
 
 	return vals
 }

--- a/html_test.go
+++ b/html_test.go
@@ -12,30 +12,37 @@ type policyTestCase struct {
 	ShouldFail bool
 }
 
+func cm(
+	key string, constraint revisor.StringConstraint,
+) revisor.ConstraintMap {
+	return revisor.ConstraintMap{
+		Keys: []string{key},
+		Constraints: map[string]revisor.StringConstraint{
+			key: constraint,
+		},
+	}
+}
+
 func TestHTMLPolicy(t *testing.T) {
 	policy := revisor.HTMLPolicy{
 		Elements: map[string]revisor.HTMLElement{
 			"em": {
-				Attributes: revisor.ConstraintMap{
-					"id": {Optional: true},
-				},
+				Attributes: cm("id", revisor.StringConstraint{
+					Optional: true,
+				}),
 			},
 			"strong": {
-				Attributes: revisor.ConstraintMap{
-					"id": {Optional: true},
-				},
+				Attributes: cm("id", revisor.StringConstraint{
+					Optional: true,
+				}),
 			},
 			"a": {
-				Attributes: revisor.ConstraintMap{
-					"href": {},
-				},
+				Attributes: cm("href", revisor.StringConstraint{}),
 			},
 			"custommark": {
-				Attributes: revisor.ConstraintMap{
-					"count": {
-						Format: "int",
-					},
-				},
+				Attributes: cm("count", revisor.StringConstraint{
+					Format: "int",
+				}),
 			},
 		},
 	}

--- a/string_constraint.go
+++ b/string_constraint.go
@@ -87,7 +87,7 @@ func (cm *ConstraintMap) UnmarshalJSON(data []byte) error {
 }
 
 func (cm *ConstraintMap) MarshalJSON() ([]byte, error) {
-	return json.Marshal(cm.Constraints)
+	return json.Marshal(cm.Constraints) //nolint: wrapcheck
 }
 
 type StringConstraint struct {

--- a/testdata/results/base-article-borked.json
+++ b/testdata/results/base-article-borked.json
@@ -3,48 +3,28 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "rel"
+        "name": "uuid"
       },
       {
         "refType": "block",
         "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "title"
-      },
-      {
-        "refType": "block",
-        "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "title"
-      },
-      {
-        "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "core/teaser"
+        "type": "core/section",
+        "rel": "subject"
       }
     ],
     "error": "cannot be empty"
+  },
+  {
+    "entity": [
+      {
+        "refType": "block",
+        "kind": "link",
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
+      }
+    ],
+    "error": "undeclared block type or rel"
   },
   {
     "entity": [
@@ -82,57 +62,33 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "uuid"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
-      }
-    ],
-    "error": "invalid UUID length: 8"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uuid"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
-      }
-    ],
-    "error": "not a valid UUID: invalid UUID length: 8"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uuid"
+        "name": "title"
       },
       {
         "refType": "block",
         "kind": "link",
-        "type": "core/section",
-        "rel": "subject"
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
       }
     ],
-    "error": "cannot be empty"
+    "error": "undeclared block attribute"
   },
   {
     "entity": [
       {
+        "refType": "attribute",
+        "name": "rel"
+      },
+      {
         "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
+        "kind": "link",
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
       }
     ],
-    "error": "there must be 1 link where type is \"core/image\" and rel is \"self\""
+    "error": "undeclared block attribute"
   },
   {
     "entity": [
@@ -151,6 +107,36 @@
   {
     "entity": [
       {
+        "refType": "attribute",
+        "name": "title"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "core/teaser"
+      }
+    ],
+    "error": "cannot be empty"
+  },
+  {
+    "entity": [
+      {
+        "refType": "data attribute",
+        "name": "text"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "core/teaser"
+      }
+    ],
+    "error": "missing required attribute"
+  },
+  {
+    "entity": [
+      {
         "refType": "data attribute",
         "name": "text"
       },
@@ -160,7 +146,7 @@
         "type": "core/heading-1"
       }
     ],
-    "error": "unclosed tag <em>"
+    "error": "unclosed tag \u003cem\u003e"
   },
   {
     "entity": [
@@ -190,33 +176,47 @@
         "type": "core/paragraph"
       }
     ],
-    "error": "invalid html after line 1 char 0: invalid html entity: unknown character entity &orci;"
+    "error": "invalid html after line 1 char 0: invalid html entity: unknown character entity \u0026orci;"
   },
   {
     "entity": [
       {
-        "refType": "data attribute",
-        "name": "text"
+        "refType": "attribute",
+        "name": "uuid"
       },
       {
         "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "core/teaser"
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
       }
     ],
-    "error": "missing required attribute"
+    "error": "not a valid UUID: invalid UUID length: 8"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "uuid"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
+      }
+    ],
+    "error": "invalid UUID length: 8"
   },
   {
     "entity": [
       {
         "refType": "block",
-        "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
       }
     ],
-    "error": "undeclared block type or rel"
+    "error": "there must be 1 link where type is \"core/image\" and rel is \"self\""
   }
 ]

--- a/testdata/results/base-example-article.json
+++ b/testdata/results/base-example-article.json
@@ -2,74 +2,13 @@
   {
     "entity": [
       {
-        "refType": "attribute",
-        "name": "rel"
-      },
-      {
         "refType": "block",
-        "kind": "link",
-        "type": "tt/picture",
-        "rel": "self"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
+        "kind": "meta",
         "index": 1,
-        "type": "tt/visual"
+        "type": "tt/slugline"
       }
     ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "type"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 1,
-        "type": "tt/visual"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "type"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 2,
-        "type": "tt/dateline"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "type"
-      },
-      {
-        "refType": "block",
-        "kind": "link",
-        "type": "tt/picture",
-        "rel": "self"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 1,
-        "type": "tt/visual"
-      }
-    ],
-    "error": "undeclared block attribute"
+    "error": "undeclared block type or rel"
   },
   {
     "entity": [
@@ -82,6 +21,100 @@
         "kind": "meta",
         "index": 1,
         "type": "tt/slugline"
+      }
+    ],
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "value"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "tt/slugline"
+      }
+    ],
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 1,
+        "type": "tt/visual"
+      }
+    ],
+    "error": "undeclared block type or rel"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "type"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 1,
+        "type": "tt/visual"
+      }
+    ],
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "data attribute",
+        "name": "caption"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 1,
+        "type": "tt/visual"
+      }
+    ],
+    "error": "unknown attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "block",
+        "kind": "link",
+        "type": "tt/picture",
+        "rel": "self"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 1,
+        "type": "tt/visual"
+      }
+    ],
+    "error": "undeclared block type or rel"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "type"
+      },
+      {
+        "refType": "block",
+        "kind": "link",
+        "type": "tt/picture",
+        "rel": "self"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 1,
+        "type": "tt/visual"
       }
     ],
     "error": "undeclared block attribute"
@@ -132,53 +165,22 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "value"
+        "name": "rel"
       },
       {
         "refType": "block",
-        "kind": "meta",
+        "kind": "link",
+        "type": "tt/picture",
+        "rel": "self"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
         "index": 1,
-        "type": "tt/slugline"
+        "type": "tt/visual"
       }
     ],
     "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 1,
-        "type": "tt/visual"
-      }
-    ],
-    "error": "undeclared block type or rel"
-  },
-  {
-    "entity": [
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 2,
-        "type": "tt/dateline"
-      }
-    ],
-    "error": "undeclared block type or rel"
-  },
-  {
-    "entity": [
-      {
-        "refType": "data attribute",
-        "name": "caption"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 1,
-        "type": "tt/visual"
-      }
-    ],
-    "error": "unknown attribute"
   },
   {
     "entity": [
@@ -247,21 +249,6 @@
     "entity": [
       {
         "refType": "data attribute",
-        "name": "text"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 2,
-        "type": "tt/dateline"
-      }
-    ],
-    "error": "unknown attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "data attribute",
         "name": "width"
       },
       {
@@ -283,15 +270,9 @@
     "entity": [
       {
         "refType": "block",
-        "kind": "link",
-        "type": "tt/picture",
-        "rel": "self"
-      },
-      {
-        "refType": "block",
         "kind": "content",
-        "index": 1,
-        "type": "tt/visual"
+        "index": 2,
+        "type": "tt/dateline"
       }
     ],
     "error": "undeclared block type or rel"
@@ -299,12 +280,31 @@
   {
     "entity": [
       {
+        "refType": "attribute",
+        "name": "type"
+      },
+      {
         "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "tt/slugline"
+        "kind": "content",
+        "index": 2,
+        "type": "tt/dateline"
       }
     ],
-    "error": "undeclared block type or rel"
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "data attribute",
+        "name": "text"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 2,
+        "type": "tt/dateline"
+      }
+    ],
+    "error": "unknown attribute"
   }
 ]

--- a/testdata/results/base-planning.json
+++ b/testdata/results/base-planning.json
@@ -2,8 +2,49 @@
   {
     "entity": [
       {
+        "refType": "block",
+        "kind": "link",
+        "type": "tt/sector",
+        "rel": "sector"
+      }
+    ],
+    "error": "undeclared block type or rel"
+  },
+  {
+    "entity": [
+      {
         "refType": "attribute",
-        "name": "rel"
+        "name": "uuid"
+      },
+      {
+        "refType": "block",
+        "kind": "link",
+        "type": "tt/sector",
+        "rel": "sector"
+      }
+    ],
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "type"
+      },
+      {
+        "refType": "block",
+        "kind": "link",
+        "type": "tt/sector",
+        "rel": "sector"
+      }
+    ],
+    "error": "undeclared block attribute"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "uri"
       },
       {
         "refType": "block",
@@ -33,57 +74,7 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "type"
-      },
-      {
-        "refType": "block",
-        "kind": "link",
-        "type": "tt/sector",
-        "rel": "sector"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "type"
-      },
-      {
-        "refType": "block",
-        "kind": "meta",
-        "type": "tt/slugline"
-      },
-      {
-        "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "core/assignment"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uri"
-      },
-      {
-        "refType": "block",
-        "kind": "link",
-        "type": "tt/sector",
-        "rel": "sector"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uuid"
+        "name": "rel"
       },
       {
         "refType": "block",
@@ -112,8 +103,24 @@
   {
     "entity": [
       {
+        "refType": "block",
+        "kind": "meta",
+        "type": "tt/slugline"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "core/assignment"
+      }
+    ],
+    "error": "undeclared block type or rel"
+  },
+  {
+    "entity": [
+      {
         "refType": "attribute",
-        "name": "value"
+        "name": "type"
       },
       {
         "refType": "block",
@@ -132,16 +139,9 @@
   {
     "entity": [
       {
-        "refType": "block",
-        "kind": "link",
-        "type": "tt/sector",
-        "rel": "sector"
-      }
-    ],
-    "error": "undeclared block type or rel"
-  },
-  {
-    "entity": [
+        "refType": "attribute",
+        "name": "value"
+      },
       {
         "refType": "block",
         "kind": "meta",
@@ -154,6 +154,6 @@
         "type": "core/assignment"
       }
     ],
-    "error": "undeclared block type or rel"
+    "error": "undeclared block attribute"
   }
 ]

--- a/testdata/results/example-article-borked.json
+++ b/testdata/results/example-article-borked.json
@@ -3,48 +3,28 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "rel"
+        "name": "uuid"
       },
       {
         "refType": "block",
         "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "title"
-      },
-      {
-        "refType": "block",
-        "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
-      }
-    ],
-    "error": "undeclared block attribute"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "title"
-      },
-      {
-        "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "core/teaser"
+        "type": "core/section",
+        "rel": "subject"
       }
     ],
     "error": "cannot be empty"
+  },
+  {
+    "entity": [
+      {
+        "refType": "block",
+        "kind": "link",
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
+      }
+    ],
+    "error": "undeclared block type or rel"
   },
   {
     "entity": [
@@ -82,57 +62,33 @@
     "entity": [
       {
         "refType": "attribute",
-        "name": "uuid"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
-      }
-    ],
-    "error": "invalid UUID length: 8"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uuid"
-      },
-      {
-        "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
-      }
-    ],
-    "error": "not a valid UUID: invalid UUID length: 8"
-  },
-  {
-    "entity": [
-      {
-        "refType": "attribute",
-        "name": "uuid"
+        "name": "title"
       },
       {
         "refType": "block",
         "kind": "link",
-        "type": "core/section",
-        "rel": "subject"
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
       }
     ],
-    "error": "cannot be empty"
+    "error": "undeclared block attribute"
   },
   {
     "entity": [
       {
+        "refType": "attribute",
+        "name": "rel"
+      },
+      {
         "refType": "block",
-        "kind": "content",
-        "index": 3,
-        "type": "core/image"
+        "kind": "link",
+        "index": 1,
+        "type": "core/articlesource",
+        "rel": "articlesource"
       }
     ],
-    "error": "there must be 1 link where type is \"core/image\" and rel is \"self\""
+    "error": "undeclared block attribute"
   },
   {
     "entity": [
@@ -151,6 +107,36 @@
   {
     "entity": [
       {
+        "refType": "attribute",
+        "name": "title"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "core/teaser"
+      }
+    ],
+    "error": "cannot be empty"
+  },
+  {
+    "entity": [
+      {
+        "refType": "data attribute",
+        "name": "text"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 1,
+        "type": "core/teaser"
+      }
+    ],
+    "error": "missing required attribute"
+  },
+  {
+    "entity": [
+      {
         "refType": "data attribute",
         "name": "text"
       },
@@ -160,7 +146,7 @@
         "type": "core/heading-1"
       }
     ],
-    "error": "unclosed tag <em>"
+    "error": "unclosed tag \u003cem\u003e"
   },
   {
     "entity": [
@@ -190,33 +176,47 @@
         "type": "core/paragraph"
       }
     ],
-    "error": "invalid html after line 1 char 0: invalid html entity: unknown character entity &orci;"
+    "error": "invalid html after line 1 char 0: invalid html entity: unknown character entity \u0026orci;"
   },
   {
     "entity": [
       {
-        "refType": "data attribute",
-        "name": "text"
+        "refType": "attribute",
+        "name": "uuid"
       },
       {
         "refType": "block",
-        "kind": "meta",
-        "index": 1,
-        "type": "core/teaser"
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
       }
     ],
-    "error": "missing required attribute"
+    "error": "not a valid UUID: invalid UUID length: 8"
+  },
+  {
+    "entity": [
+      {
+        "refType": "attribute",
+        "name": "uuid"
+      },
+      {
+        "refType": "block",
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
+      }
+    ],
+    "error": "invalid UUID length: 8"
   },
   {
     "entity": [
       {
         "refType": "block",
-        "kind": "link",
-        "index": 1,
-        "type": "core/articlesource",
-        "rel": "articlesource"
+        "kind": "content",
+        "index": 3,
+        "type": "core/image"
       }
     ],
-    "error": "undeclared block type or rel"
+    "error": "there must be 1 link where type is \"core/image\" and rel is \"self\""
   }
 ]

--- a/testdata/results/test-geo.json
+++ b/testdata/results/test-geo.json
@@ -33,21 +33,6 @@
     "entity": [
       {
         "refType": "data attribute",
-        "name": "position"
-      },
-      {
-        "refType": "block",
-        "kind": "meta",
-        "index": 2,
-        "type": "core/place"
-      }
-    ],
-    "error": "WKT validation: geometry is not a point"
-  },
-  {
-    "entity": [
-      {
-        "refType": "data attribute",
         "name": "position_3d"
       },
       {
@@ -73,5 +58,20 @@
       }
     ],
     "error": "WKT validation: unexpected coordinate type \"z\" where none was expected"
+  },
+  {
+    "entity": [
+      {
+        "refType": "data attribute",
+        "name": "position"
+      },
+      {
+        "refType": "block",
+        "kind": "meta",
+        "index": 2,
+        "type": "core/place"
+      }
+    ],
+    "error": "WKT validation: geometry is not a point"
   }
 ]

--- a/testdata/results/test-transcript.json
+++ b/testdata/results/test-transcript.json
@@ -45,6 +45,6 @@
         "name": "url"
       }
     ],
-    "error": "must be one of: \"https://example.com/transcript\", \"https://example.com/transcipt\" (deprecated)"
+    "error": "must be one of: \"https://example.com/transcipt\" (deprecated), \"https://example.com/transcript\""
   }
 ]

--- a/validation.go
+++ b/validation.go
@@ -563,6 +563,7 @@ func (v *Validator) validateBlock(
 	}
 
 	declaredAttributes := make(map[blockAttributeKey]bool)
+
 	var declaredKeys []blockAttributeKey
 
 	for _, set := range constraintSets {
@@ -595,6 +596,7 @@ func (v *Validator) validateBlock(
 
 				if !declaredAttributes[k] {
 					declaredAttributes[k] = true
+
 					declaredKeys = append(declaredKeys, k)
 				}
 			}

--- a/validation_test.go
+++ b/validation_test.go
@@ -351,6 +351,8 @@ func testAgainstGolden(
 			goldie, err := json.MarshalIndent(got, "", "  ")
 			must(t, err, "marshal new golden results")
 
+			goldie = append(goldie, '\n')
+
 			err = os.WriteFile(goldenPath, goldie, 0o600)
 			must(t, err, "write updated golden file")
 		}


### PR DESCRIPTION
This looks like a messy diff, but it's mostly re-ordering in the test data. The thing that I'm trying to fix here is that we'll always get a large diff in the test result data when running tests with `REGENERATE=true` because the evaluation order is non-deterministic due to iterations over maps.

To make this verifiable I split the change into two parts, the first commit changes the output so that it's deterministic, but I'm not touching the test files (except for the the [output of the non deterministic enum check](testdata/results/test-transcript.json) that was [causing the flaky test](https://github.com/ttab/revisor/actions/runs/9465993673/job/26076679820#step:4:28) that set me on this path) so that we can verify that the new code passes the old tests. In the second commit I've added all the re-generated files.