### PR TITLE
add document pruning to remove non-conforming blocks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.8
+          version: v2.10
           args: --timeout=4m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - goconst
+        path: _test\.go
 formatters:
   enable:
     - gci

--- a/block_constraint.go
+++ b/block_constraint.go
@@ -353,6 +353,39 @@ func blockAttribute(block *newsdoc.Block, name string) (string, bool) {
 	return "", false
 }
 
+func setBlockAttribute(block *newsdoc.Block, name string, value string) bool {
+	switch blockAttributeKey(name) {
+	case blockAttrUUID:
+		block.UUID = value
+	case blockAttrID:
+		block.ID = value
+	case blockAttrType:
+		block.Type = value
+	case blockAttrURI:
+		block.URI = value
+	case blockAttrURL:
+		block.URL = value
+	case blockAttrTitle:
+		block.Title = value
+	case blockAttrRel:
+		block.Rel = value
+	case blockAttrName:
+		block.Name = value
+	case blockAttrValue:
+		block.Value = value
+	case blockAttrContentType:
+		block.Contenttype = value
+	case blockAttrRole:
+		block.Role = value
+	case blockAttrSensitivity:
+		block.Sensitivity = value
+	default:
+		return false
+	}
+
+	return true
+}
+
 // DescribeCountConstraint returns a human readable (english) description of the
 // count contstraint for the block constraint.
 func (bc BlockConstraint) DescribeCountConstraint(kind BlockKind) string {

--- a/block_constraint.go
+++ b/block_constraint.go
@@ -353,7 +353,7 @@ func blockAttribute(block *newsdoc.Block, name string) (string, bool) {
 	return "", false
 }
 
-func setBlockAttribute(block *newsdoc.Block, name string, value string) bool {
+func setBlockAttribute(block *newsdoc.Block, name string, value string) {
 	switch blockAttributeKey(name) {
 	case blockAttrUUID:
 		block.UUID = value
@@ -379,11 +379,7 @@ func setBlockAttribute(block *newsdoc.Block, name string, value string) bool {
 		block.Role = value
 	case blockAttrSensitivity:
 		block.Sensitivity = value
-	default:
-		return false
 	}
-
-	return true
 }
 
 // DescribeCountConstraint returns a human readable (english) description of the

--- a/cmd/revisor/main.go
+++ b/cmd/revisor/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
+		_, _ = fmt.Fprintln(os.Stderr, err.Error()) //nolint:gosec // stderr, not HTTP output
 
 		os.Exit(1)
 	}

--- a/document_constraint.go
+++ b/document_constraint.go
@@ -106,6 +106,27 @@ func documentMatchAttribute(d *newsdoc.Document, name string, variants []Variant
 	return "", false
 }
 
+func setDocumentAttribute(d *newsdoc.Document, name string, value string) bool {
+	switch documentAttributeKey(name) {
+	case docAttrUUID:
+		d.UUID = value
+	case docAttrType:
+		d.Type = value
+	case docAttrURI:
+		d.URI = value
+	case docAttrURL:
+		d.URL = value
+	case docAttrTitle:
+		d.Title = value
+	case docAttrLanguage:
+		d.Language = value
+	default:
+		return false
+	}
+
+	return true
+}
+
 func documentAttribute(d *newsdoc.Document, name string) (string, bool) {
 	switch documentAttributeKey(name) {
 	case docAttrUUID:

--- a/prune.go
+++ b/prune.go
@@ -1,0 +1,732 @@
+package revisor
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/ttab/newsdoc"
+)
+
+type pruneStatus int
+
+const (
+	pruneOK       pruneStatus = iota // Valid or fixed.
+	pruneRemoveMe                    // Caller should remove this block.
+)
+
+// Prune modifies the document to remove non-conforming parts where possible,
+// and returns errors for things that cannot be fixed. Blocks that fail
+// validation are removed if their count constraints allow it; otherwise the
+// errors cascade up to the nearest removable ancestor, or are reported at the
+// document root.
+func (v *Validator) Prune(
+	ctx context.Context, document *newsdoc.Document,
+) ([]ValidationResult, error) {
+	var res []ValidationResult
+
+	var (
+		blockConstraints     []BlockConstraintSet
+		attributeConstraints []ConstraintMap
+	)
+
+	var declared bool
+
+	vCtx := ValidationContext{
+		coll:         ValueDiscarder{},
+		ValidateHTML: v.validateHTML,
+		ValidateEnum: v.enums.ValidValue,
+	}
+
+	_, err := uuid.Parse(document.UUID)
+	if err != nil {
+		res = append(res, ValidationResult{
+			Entity: []EntityRef{{
+				RefType: RefTypeAttribute,
+				Name:    "uuid",
+			}},
+			Error: fmt.Sprintf("not a valid UUID: %v", err),
+		})
+	}
+
+	for i := range v.documents {
+		match := v.documents[i].Matches(document, &vCtx)
+		if match == NoMatch {
+			continue
+		}
+
+		if match == MatchDeclaration {
+			declared = true
+		}
+
+		blockConstraints = append(blockConstraints, v.documents[i])
+		attributeConstraints = append(
+			attributeConstraints, v.documents[i].Attributes)
+	}
+
+	if !declared {
+		res = append(res, ValidationResult{
+			Error: fmt.Sprintf(
+				"undeclared document type %q", document.Type),
+		})
+	}
+
+	res = append(res, pruneDocumentAttributes(
+		attributeConstraints, document, &vCtx)...)
+
+	for _, kind := range blockKinds {
+		blocks := getDocumentBlocks(document, kind)
+
+		status, pruned, errs, err := v.pruneBlockSlice(
+			ctx, document, blocks, kind,
+			blockConstraints, vCtx, true,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		setDocumentBlocks(document, kind, pruned)
+		res = append(res, errs...)
+
+		// At document level pruneRemoveMe should not happen because
+		// pruneBlockSlice with documentLevel=true reports errors instead
+		// of cascading. This is just defensive.
+		_ = status
+	}
+
+	return res, nil
+}
+
+// getDocumentBlocks returns the block slice for the given kind from a document.
+func getDocumentBlocks(doc *newsdoc.Document, kind BlockKind) []newsdoc.Block {
+	switch kind {
+	case BlockKindLink:
+		return doc.Links
+	case BlockKindMeta:
+		return doc.Meta
+	case BlockKindContent:
+		return doc.Content
+	}
+
+	return nil
+}
+
+// setDocumentBlocks sets the block slice for the given kind on a document.
+func setDocumentBlocks(doc *newsdoc.Document, kind BlockKind, blocks []newsdoc.Block) {
+	switch kind {
+	case BlockKindLink:
+		doc.Links = blocks
+	case BlockKindMeta:
+		doc.Meta = blocks
+	case BlockKindContent:
+		doc.Content = blocks
+	}
+}
+
+// getNestedBlocks returns the block slice for the given kind from a block.
+func getNestedBlocks(block *newsdoc.Block, kind BlockKind) []newsdoc.Block {
+	switch kind {
+	case BlockKindLink:
+		return block.Links
+	case BlockKindMeta:
+		return block.Meta
+	case BlockKindContent:
+		return block.Content
+	}
+
+	return nil
+}
+
+// setNestedBlocks sets the block slice for the given kind on a block.
+func setNestedBlocks(block *newsdoc.Block, kind BlockKind, blocks []newsdoc.Block) {
+	switch kind {
+	case BlockKindLink:
+		block.Links = blocks
+	case BlockKindMeta:
+		block.Meta = blocks
+	case BlockKindContent:
+		block.Content = blocks
+	}
+}
+
+// blockRemovalAllowed checks whether removing one block matching this
+// constraint is safe given the remaining count after removal.
+func blockRemovalAllowed(
+	constraint *BlockConstraint, remainingAfterRemoval int,
+) bool {
+	if constraint.Count != nil &&
+		remainingAfterRemoval < *constraint.Count {
+		return false
+	}
+
+	if constraint.MinCount != nil &&
+		remainingAfterRemoval < *constraint.MinCount {
+		return false
+	}
+
+	return true
+}
+
+// blockMatchInfo tracks which constraints matched a block during pruning.
+type blockMatchInfo struct {
+	defined                bool
+	matchedConstraints     []BlockConstraintSet
+	matchedAttrConstraints []ConstraintMap
+	matchedDataConstraints []ConstraintMap
+	matchedBlockPtrs       []*BlockConstraint
+	declaredAttributes     map[blockAttributeKey]bool
+}
+
+// pruneBlockSlice prunes a slice of blocks, removing invalid ones where count
+// constraints allow it.
+func (v *Validator) pruneBlockSlice(
+	ctx context.Context, doc *newsdoc.Document,
+	blocks []newsdoc.Block, kind BlockKind,
+	constraintSets []BlockConstraintSet,
+	vCtx ValidationContext,
+	documentLevel bool,
+) (pruneStatus, []newsdoc.Block, []ValidationResult, error) {
+	if len(blocks) == 0 {
+		return pruneOK, blocks, nil, nil
+	}
+
+	// Phase 1: Match all blocks against constraints.
+	matchInfos := make([]blockMatchInfo, len(blocks))
+	counts := make(map[*BlockConstraint]int)
+
+	for i := range blocks {
+		matchInfos[i] = matchBlock(
+			&blocks[i], kind, constraintSets, counts)
+	}
+
+	// Phase 2: Prune each block, marking for removal if needed.
+	type removalCandidate struct {
+		index      int
+		cascadeErr []ValidationResult
+	}
+
+	var (
+		removals []removalCandidate
+		res      []ValidationResult
+	)
+
+	for i := range blocks {
+		if !matchInfos[i].defined {
+			// Undeclared block → mark for removal.
+			removals = append(removals, removalCandidate{
+				index: i,
+				cascadeErr: []ValidationResult{{
+					Error: "undeclared block type or rel",
+				}},
+			})
+
+			continue
+		}
+
+		status, errs, err := v.pruneBlock(
+			ctx, doc, &blocks[i], vCtx,
+			matchInfos[i].matchedConstraints,
+			matchInfos[i].matchedAttrConstraints,
+			matchInfos[i].matchedDataConstraints,
+			matchInfos[i].declaredAttributes,
+		)
+		if err != nil {
+			return pruneOK, blocks, nil, err
+		}
+
+		if status == pruneRemoveMe {
+			removals = append(removals, removalCandidate{
+				index:      i,
+				cascadeErr: errs,
+			})
+
+			continue
+		}
+
+		res = append(res, errs...)
+	}
+
+	// Phase 3: Check if each removal is allowed by count constraints.
+	// Build a map of how many we plan to remove per constraint.
+	removalCountDelta := make(map[*BlockConstraint]int)
+
+	for _, r := range removals {
+		for _, ptr := range matchInfos[r.index].matchedBlockPtrs {
+			removalCountDelta[ptr]++
+		}
+	}
+
+	var (
+		allowedRemovals   []int
+		forbiddenRemovals []removalCandidate
+	)
+
+	for _, r := range removals {
+		forbidden := false
+
+		for _, ptr := range matchInfos[r.index].matchedBlockPtrs {
+			remaining := counts[ptr] - removalCountDelta[ptr]
+			if !blockRemovalAllowed(ptr, remaining) {
+				forbidden = true
+
+				break
+			}
+		}
+
+		if forbidden {
+			forbiddenRemovals = append(forbiddenRemovals, r)
+		} else {
+			allowedRemovals = append(allowedRemovals, r.index)
+		}
+	}
+
+	// Phase 4: Handle forbidden removals.
+	for _, r := range forbiddenRemovals {
+		entity := EntityRef{
+			RefType:   RefTypeBlock,
+			Index:     r.index,
+			BlockKind: kind,
+			Type:      blocks[r.index].Type,
+			Rel:       blocks[r.index].Rel,
+		}
+
+		if documentLevel {
+			// At document level, report cascade errors with entity.
+			for j := range r.cascadeErr {
+				r.cascadeErr[j].Entity = append(
+					r.cascadeErr[j].Entity, entity)
+			}
+
+			res = append(res, r.cascadeErr...)
+		} else {
+			// At nested level, propagate up.
+			for j := range r.cascadeErr {
+				r.cascadeErr[j].Entity = append(
+					r.cascadeErr[j].Entity, entity)
+			}
+
+			return pruneRemoveMe, blocks, r.cascadeErr, nil
+		}
+	}
+
+	// Phase 5: Execute allowed removals (backwards for index stability).
+	slices.Sort(allowedRemovals)
+
+	for i := len(allowedRemovals) - 1; i >= 0; i-- {
+		blocks = slices.Delete(blocks, allowedRemovals[i], allowedRemovals[i]+1)
+	}
+
+	// Phase 5.5: Remove excess blocks that exceed Count or MaxCount,
+	// keeping the first N allowed blocks per constraint.
+	blocks = pruneExcessBlocks(blocks, kind, constraintSets)
+
+	// Phase 6: Post-removal count check (recount from scratch after all
+	// removals).
+	finalCounts := countBlockMatches(blocks, kind, constraintSets)
+
+	for i := range constraintSets {
+		for _, constraint := range constraintSets[i].BlockConstraints(kind) {
+			count := finalCounts[constraint]
+
+			minOK := nilOrGTE(constraint.MinCount, count)
+			exactOK := nilOrEqual(constraint.Count, count)
+
+			if !minOK || !exactOK {
+				errResult := ValidationResult{
+					Error: constraint.DescribeCountConstraint(kind),
+				}
+
+				if documentLevel {
+					res = append(res, errResult)
+				} else {
+					return pruneRemoveMe, blocks,
+						[]ValidationResult{errResult}, nil
+				}
+			}
+		}
+	}
+
+	return pruneOK, blocks, res, nil
+}
+
+// matchBlock matches a single block against constraint sets and populates
+// counts.
+func matchBlock(
+	b *newsdoc.Block, kind BlockKind,
+	constraintSets []BlockConstraintSet,
+	counts map[*BlockConstraint]int,
+) blockMatchInfo {
+	info := blockMatchInfo{
+		declaredAttributes: make(map[blockAttributeKey]bool),
+	}
+
+	for _, set := range constraintSets {
+		constraints := set.BlockConstraints(kind)
+
+		for _, constraint := range constraints {
+			match, attributes := constraint.Matches(b)
+			if match == NoMatch {
+				continue
+			}
+
+			if match == MatchDeclaration {
+				info.defined = true
+			}
+
+			for _, a := range attributes {
+				info.declaredAttributes[blockAttributeKey(a)] = true
+			}
+
+			counts[constraint]++
+
+			info.matchedBlockPtrs = append(
+				info.matchedBlockPtrs, constraint)
+			info.matchedConstraints = append(
+				info.matchedConstraints, constraint)
+			info.matchedAttrConstraints = append(
+				info.matchedAttrConstraints, constraint.Attributes)
+			info.matchedDataConstraints = append(
+				info.matchedDataConstraints, constraint.Data)
+		}
+	}
+
+	return info
+}
+
+// pruneExcessBlocks removes blocks that exceed a constraint's Count or
+// MaxCount limit, keeping the first N matching blocks per constraint.
+func pruneExcessBlocks(
+	blocks []newsdoc.Block, kind BlockKind,
+	constraintSets []BlockConstraintSet,
+) []newsdoc.Block {
+	toRemove := make(map[int]bool)
+
+	for _, set := range constraintSets {
+		for _, constraint := range set.BlockConstraints(kind) {
+			limit := constraintMaxAllowed(constraint)
+			if limit < 0 {
+				continue
+			}
+
+			// Collect indices of non-removed blocks matching this
+			// constraint.
+			var matching []int
+
+			for i := range blocks {
+				if toRemove[i] {
+					continue
+				}
+
+				match, _ := constraint.Matches(&blocks[i])
+				if match != NoMatch {
+					matching = append(matching, i)
+				}
+			}
+
+			if len(matching) <= limit {
+				continue
+			}
+
+			// Keep the first `limit` blocks, mark the rest for
+			// removal.
+			for j := limit; j < len(matching); j++ {
+				toRemove[matching[j]] = true
+			}
+		}
+	}
+
+	if len(toRemove) == 0 {
+		return blocks
+	}
+
+	var removals []int
+
+	for idx := range toRemove {
+		removals = append(removals, idx)
+	}
+
+	slices.Sort(removals)
+
+	for i := len(removals) - 1; i >= 0; i-- {
+		blocks = slices.Delete(blocks, removals[i], removals[i]+1)
+	}
+
+	return blocks
+}
+
+// constraintMaxAllowed returns the maximum number of blocks allowed by a
+// constraint's Count/MaxCount, or -1 if there is no upper limit.
+func constraintMaxAllowed(constraint *BlockConstraint) int {
+	limit := -1
+
+	if constraint.Count != nil {
+		limit = *constraint.Count
+	}
+
+	if constraint.MaxCount != nil {
+		if limit < 0 || *constraint.MaxCount < limit {
+			limit = *constraint.MaxCount
+		}
+	}
+
+	return limit
+}
+
+// countBlockMatches counts how many blocks in the slice match each constraint.
+func countBlockMatches(
+	blocks []newsdoc.Block, kind BlockKind,
+	constraintSets []BlockConstraintSet,
+) map[*BlockConstraint]int {
+	counts := make(map[*BlockConstraint]int)
+
+	for i := range blocks {
+		for _, set := range constraintSets {
+			for _, constraint := range set.BlockConstraints(kind) {
+				match, _ := constraint.Matches(&blocks[i])
+				if match != NoMatch {
+					counts[constraint]++
+				}
+			}
+		}
+	}
+
+	return counts
+}
+
+// pruneBlock prunes a single block's attributes, data, and child blocks.
+func (v *Validator) pruneBlock(
+	ctx context.Context, doc *newsdoc.Document,
+	b *newsdoc.Block, vCtx ValidationContext,
+	matchedConstraints []BlockConstraintSet,
+	matchedAttrConstraints []ConstraintMap,
+	matchedDataConstraints []ConstraintMap,
+	declaredAttributes map[blockAttributeKey]bool,
+) (pruneStatus, []ValidationResult, error) {
+	var res []ValidationResult
+
+	// Prune attributes.
+	status, errs := pruneBlockAttributes(
+		matchedAttrConstraints, b, &vCtx, declaredAttributes)
+	if status == pruneRemoveMe {
+		return pruneRemoveMe, errs, nil
+	}
+
+	res = append(res, errs...)
+
+	// Prune data.
+	status, errs = pruneBlockData(b, matchedDataConstraints, &vCtx)
+	if status == pruneRemoveMe {
+		return pruneRemoveMe, errs, nil
+	}
+
+	res = append(res, errs...)
+
+	// Prune child blocks.
+	for _, kind := range blockKinds {
+		childBlocks := getNestedBlocks(b, kind)
+
+		status, pruned, errs, err := v.pruneBlockSlice(
+			ctx, doc, childBlocks, kind,
+			matchedConstraints, vCtx, false,
+		)
+		if err != nil {
+			return pruneOK, nil, err
+		}
+
+		setNestedBlocks(b, kind, pruned)
+
+		if status == pruneRemoveMe {
+			return pruneRemoveMe, errs, nil
+		}
+
+		res = append(res, errs...)
+	}
+
+	return pruneOK, res, nil
+}
+
+// pruneBlockAttributes prunes block attributes. Invalid attributes that can be
+// cleared (AllowEmpty or Optional) are set to "". Undeclared non-empty
+// attributes are cleared. If a required attribute is invalid and cannot be
+// fixed, pruneRemoveMe is returned.
+func pruneBlockAttributes(
+	constraints []ConstraintMap, b *newsdoc.Block,
+	vCtx *ValidationContext,
+	declaredAttributes map[blockAttributeKey]bool,
+) (pruneStatus, []ValidationResult) {
+	var res []ValidationResult
+
+	for i := range constraints {
+		for _, k := range constraints[i].Keys {
+			declaredAttributes[blockAttributeKey(k)] = true
+
+			value, ok := blockAttribute(b, k)
+			check := constraints[i].Constraints[k]
+
+			// Mirror validation: optional attributes allow empty.
+			check.AllowEmpty = check.AllowEmpty || check.Optional
+
+			_, err := check.Validate(value, ok, vCtx)
+			if err == nil {
+				continue
+			}
+
+			ref := EntityRef{
+				RefType: RefTypeAttribute,
+				Name:    k,
+			}
+
+			if check.AllowEmpty || check.Optional {
+				setBlockAttribute(b, k, "")
+
+				continue
+			}
+
+			// Required attribute with invalid value → can't fix.
+			return pruneRemoveMe, []ValidationResult{{
+				Entity: []EntityRef{ref},
+				Error:  err.Error(),
+			}}
+		}
+	}
+
+	// Clear undeclared non-empty attributes.
+	for _, attr := range allBlockAttributes {
+		if declaredAttributes[attr] {
+			continue
+		}
+
+		value, ok := blockAttribute(b, string(attr))
+		if ok && value != "" {
+			setBlockAttribute(b, string(attr), "")
+		}
+	}
+
+	return pruneOK, res
+}
+
+// pruneBlockData prunes the data map of a block. Unknown keys are deleted.
+// Optional keys with invalid values are deleted. AllowEmpty keys with invalid
+// values are set to "". Required keys with invalid values trigger
+// pruneRemoveMe.
+func pruneBlockData(
+	b *newsdoc.Block, constraints []ConstraintMap,
+	vCtx *ValidationContext,
+) (pruneStatus, []ValidationResult) {
+	var res []ValidationResult
+
+	known := make(map[string]bool)
+
+	for i := range constraints {
+		for _, k := range constraints[i].Keys {
+			check := constraints[i].Constraints[k]
+
+			var (
+				value string
+				ok    bool
+			)
+
+			if b.Data != nil {
+				value, ok = b.Data[k]
+			}
+
+			if ok {
+				known[k] = true
+			}
+
+			ref := EntityRef{
+				RefType: RefTypeData,
+				Name:    k,
+			}
+
+			if !ok && !check.Optional {
+				// Missing required data → can't fix.
+				return pruneRemoveMe, []ValidationResult{{
+					Entity: []EntityRef{ref},
+					Error:  "missing required attribute",
+				}}
+			}
+
+			if !ok {
+				continue
+			}
+
+			_, err := check.Validate(value, true, vCtx)
+			if err == nil {
+				continue
+			}
+
+			if check.AllowEmpty {
+				b.Data[k] = ""
+
+				continue
+			}
+
+			if check.Optional {
+				delete(b.Data, k)
+
+				continue
+			}
+
+			// Required data with invalid value → can't fix.
+			return pruneRemoveMe, []ValidationResult{{
+				Entity: []EntityRef{ref},
+				Error:  err.Error(),
+			}}
+		}
+	}
+
+	// Delete unknown keys.
+	for k := range b.Data {
+		if !known[k] {
+			delete(b.Data, k)
+		}
+	}
+
+	if len(b.Data) == 0 {
+		b.Data = nil
+	}
+
+	return pruneOK, res
+}
+
+// pruneDocumentAttributes prunes document-level attributes. Invalid values
+// that can be cleared are set to "". Unfixable errors are reported directly
+// since there is no cascade at document level.
+func pruneDocumentAttributes(
+	constraints []ConstraintMap, d *newsdoc.Document,
+	vCtx *ValidationContext,
+) []ValidationResult {
+	var res []ValidationResult
+
+	for i := range constraints {
+		for _, k := range constraints[i].Keys {
+			value, ok := documentAttribute(d, k)
+			check := constraints[i].Constraints[k]
+
+			_, err := check.Validate(value, ok, vCtx)
+			if err == nil {
+				continue
+			}
+
+			ref := EntityRef{
+				RefType: RefTypeAttribute,
+				Name:    k,
+			}
+
+			if check.AllowEmpty || check.Optional {
+				setDocumentAttribute(d, k, "")
+
+				continue
+			}
+
+			res = append(res, ValidationResult{
+				Entity: []EntityRef{ref},
+				Error:  err.Error(),
+			})
+		}
+	}
+
+	return res
+}

--- a/prune.go
+++ b/prune.go
@@ -87,6 +87,7 @@ func (v *Validator) Prune(
 		}
 
 		setDocumentBlocks(document, kind, pruned)
+
 		res = append(res, errs...)
 
 		// At document level pruneRemoveMe should not happen because

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,0 +1,1083 @@
+package revisor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ttab/newsdoc"
+	"github.com/ttab/revisor"
+)
+
+func intPtr(n int) *int {
+	return &n
+}
+
+func newTestValidator(t *testing.T, sets ...revisor.ConstraintSet) *revisor.Validator {
+	t.Helper()
+
+	v, err := revisor.NewValidator(sets...)
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	return v
+}
+
+func simpleConstraints() revisor.ConstraintSet {
+	return revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Attributes: revisor.MakeConstraintMap(
+					map[string]revisor.StringConstraint{
+						"title": {AllowEmpty: true},
+					},
+				),
+				Links: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/link",
+							Rel:  "link",
+						},
+						Attributes: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"uri": {},
+							},
+						),
+					},
+				},
+				Meta: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/meta",
+						},
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"key": {},
+							},
+						),
+					},
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/optional-data",
+						},
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"opt": {Optional: true},
+								"ae":  {AllowEmpty: true},
+							},
+						),
+					},
+				},
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/text",
+						},
+						Attributes: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"role": {
+									Optional: true,
+									Enum:     []string{"heading", "body"},
+								},
+							},
+						),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"text": {},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+}
+
+func validDocument() *newsdoc.Document {
+	return &newsdoc.Document{
+		UUID:     "00000000-0000-0000-0000-000000000001",
+		Type:     "test/article",
+		Title:    "Test Article",
+		Language: "en",
+		Content: []newsdoc.Block{
+			{
+				Type: "test/text",
+				Data: map[string]string{
+					"text": "Hello world",
+				},
+			},
+		},
+		Meta: []newsdoc.Block{
+			{
+				Type: "test/meta",
+				Data: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		Links: []newsdoc.Block{
+			{
+				Type: "test/link",
+				Rel:  "link",
+				URI:  "http://example.com",
+			},
+		},
+	}
+}
+
+func TestPruneValidDocument(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors for valid document, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// Document should be unchanged.
+	if len(doc.Content) != 1 {
+		t.Errorf("expected 1 content block, got %d", len(doc.Content))
+	}
+
+	if len(doc.Meta) != 1 {
+		t.Errorf("expected 1 meta block, got %d", len(doc.Meta))
+	}
+
+	if len(doc.Links) != 1 {
+		t.Errorf("expected 1 link, got %d", len(doc.Links))
+	}
+}
+
+func TestPruneUnknownDataKeysRemoved(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+	doc.Meta[0].Data["unknown"] = "should be removed"
+	doc.Meta[0].Data["another"] = "also removed"
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if _, ok := doc.Meta[0].Data["unknown"]; ok {
+		t.Error("expected unknown data key to be removed")
+	}
+
+	if _, ok := doc.Meta[0].Data["another"]; ok {
+		t.Error("expected another data key to be removed")
+	}
+
+	if doc.Meta[0].Data["key"] != "value" {
+		t.Errorf("expected known data key to be preserved, got %q",
+			doc.Meta[0].Data["key"])
+	}
+}
+
+func TestPruneUndeclaredBlockAttributeCleared(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	// Set an undeclared attribute on a content block.
+	doc.Content[0].Title = "unexpected title"
+	doc.Content[0].Sensitivity = "high"
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if doc.Content[0].Title != "" {
+		t.Errorf("expected title to be cleared, got %q",
+			doc.Content[0].Title)
+	}
+
+	if doc.Content[0].Sensitivity != "" {
+		t.Errorf("expected sensitivity to be cleared, got %q",
+			doc.Content[0].Sensitivity)
+	}
+}
+
+func TestPruneInvalidAttributeWithAllowEmpty(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	// Role has enum constraint with Optional=true, so invalid value should
+	// be cleared.
+	doc.Content[0].Role = "invalid-role"
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if doc.Content[0].Role != "" {
+		t.Errorf("expected role to be cleared, got %q",
+			doc.Content[0].Role)
+	}
+}
+
+func TestPruneInvalidOptionalDataDeleted(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	doc.Meta = append(doc.Meta, newsdoc.Block{
+		Type: "test/optional-data",
+		Data: map[string]string{
+			"opt": "", // Invalid: empty not allowed for non-AllowEmpty.
+			"ae":  "", // Valid: AllowEmpty allows this.
+		},
+	})
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// "opt" key has Optional → should be deleted when invalid.
+	if _, ok := doc.Meta[1].Data["opt"]; ok {
+		t.Error("expected optional data key 'opt' to be deleted")
+	}
+}
+
+func TestPruneUndeclaredBlockRemoved(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	doc.Content = append(doc.Content, newsdoc.Block{
+		Type: "unknown/block",
+		Data: map[string]string{
+			"text": "this should be removed",
+		},
+	})
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if len(doc.Content) != 1 {
+		t.Errorf("expected 1 content block after pruning, got %d",
+			len(doc.Content))
+	}
+
+	if doc.Content[0].Type != "test/text" {
+		t.Error("wrong block was removed")
+	}
+}
+
+func TestPruneRequiredBlockNotRemoved(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Meta: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/required",
+						},
+						Count: intPtr(1),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"value": {
+									Format: revisor.StringFormatInt,
+								},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Meta: []newsdoc.Block{
+			{
+				Type: "test/required",
+				Data: map[string]string{
+					"value": "not-an-int",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should report error since block can't be removed (Count=1).
+	if len(res) == 0 {
+		t.Fatal("expected errors for required block with bad data")
+	}
+
+	// Block should still be present.
+	if len(doc.Meta) != 1 {
+		t.Errorf("expected meta block to remain, got %d blocks",
+			len(doc.Meta))
+	}
+}
+
+func TestPruneCascadeNestedUnfixableRemoved(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/wrapper",
+						},
+						Content: []*revisor.BlockConstraint{
+							{
+								Declares: &revisor.BlockSignature{
+									Type: "test/inner",
+								},
+								Data: revisor.MakeConstraintMap(
+									map[string]revisor.StringConstraint{
+										"required": {},
+									},
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{
+				Type: "test/wrapper",
+				Content: []newsdoc.Block{
+					{
+						Type: "test/inner",
+						Data: map[string]string{
+							"required": "", // Empty, but not AllowEmpty.
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// The inner block should be removed (no count constraint), and the
+	// wrapper stays since it is itself valid.
+	if len(doc.Content) != 1 {
+		t.Fatalf("expected wrapper to remain, got %d blocks",
+			len(doc.Content))
+	}
+
+	if len(doc.Content[0].Content) != 0 {
+		t.Errorf("expected inner blocks to be removed, got %d",
+			len(doc.Content[0].Content))
+	}
+}
+
+func TestPruneCascadeToRootReportsError(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/wrapper",
+						},
+						MinCount: intPtr(1),
+						Content: []*revisor.BlockConstraint{
+							{
+								Declares: &revisor.BlockSignature{
+									Type: "test/inner",
+								},
+								MinCount: intPtr(1),
+								Data: revisor.MakeConstraintMap(
+									map[string]revisor.StringConstraint{
+										"required": {},
+									},
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{
+				Type: "test/wrapper",
+				Content: []newsdoc.Block{
+					{
+						Type: "test/inner",
+						Data: map[string]string{
+							"required": "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Errors should cascade all the way to root and be reported.
+	if len(res) == 0 {
+		t.Fatal("expected errors from cascade to root")
+	}
+
+	// Check that we get error with entity chain.
+	found := false
+
+	for _, r := range res {
+		if len(r.Entity) >= 2 {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected error with entity chain of depth >= 2")
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// Both wrapper and inner should still be present.
+	if len(doc.Content) != 1 {
+		t.Errorf("expected wrapper to remain, got %d blocks",
+			len(doc.Content))
+	}
+
+	if len(doc.Content[0].Content) != 1 {
+		t.Errorf("expected inner to remain, got %d blocks",
+			len(doc.Content[0].Content))
+	}
+}
+
+func TestPruneMultipleBlocksRemovedSameSlice(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+	doc := validDocument()
+
+	// Add multiple undeclared blocks interspersed with valid ones.
+	doc.Content = []newsdoc.Block{
+		{Type: "unknown/a"},
+		{
+			Type: "test/text",
+			Data: map[string]string{"text": "first"},
+		},
+		{Type: "unknown/b"},
+		{
+			Type: "test/text",
+			Data: map[string]string{"text": "second"},
+		},
+		{Type: "unknown/c"},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if len(doc.Content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(doc.Content))
+	}
+
+	if doc.Content[0].Data["text"] != "first" {
+		t.Errorf("expected first valid block, got %q",
+			doc.Content[0].Data["text"])
+	}
+
+	if doc.Content[1].Data["text"] != "second" {
+		t.Errorf("expected second valid block, got %q",
+			doc.Content[1].Data["text"])
+	}
+}
+
+func TestPruneCountConstraintRespectsMinCount(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/text",
+						},
+						MinCount: intPtr(2),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"text": {},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{
+				Type: "test/text",
+				Data: map[string]string{"text": "valid"},
+			},
+			{
+				Type: "test/text",
+				Data: map[string]string{"text": ""},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The second block has invalid data (empty required text), but removing
+	// it would violate MinCount=2. So we should get an error and both
+	// blocks should remain.
+	if len(res) == 0 {
+		t.Fatal("expected errors since removal would violate MinCount")
+	}
+
+	if len(doc.Content) != 2 {
+		t.Errorf("expected both blocks to remain, got %d",
+			len(doc.Content))
+	}
+}
+
+func TestPruneDataNilAfterAllKeysRemoved(t *testing.T) {
+	// Use a constraint where all data keys are optional, so the block
+	// survives even after unknown keys are removed.
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Meta: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/allopt",
+						},
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"opt1": {Optional: true},
+								"opt2": {Optional: true},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Meta: []newsdoc.Block{
+			{
+				Type: "test/allopt",
+				Data: map[string]string{
+					"unknown1": "val1",
+					"unknown2": "val2",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if len(doc.Meta) != 1 {
+		t.Fatalf("expected 1 meta block, got %d", len(doc.Meta))
+	}
+
+	// Data should be nil after all unknown keys are removed.
+	if doc.Meta[0].Data != nil {
+		t.Errorf("expected data to be nil, got %v", doc.Meta[0].Data)
+	}
+}
+
+func TestPruneDocumentAttribute(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Attributes: revisor.MakeConstraintMap(
+					map[string]revisor.StringConstraint{
+						"language": {
+							AllowEmpty: true,
+							Enum:       []string{"en", "sv"},
+						},
+					},
+				),
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID:     "00000000-0000-0000-0000-000000000001",
+		Type:     "test/article",
+		Language: "fr",
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// Language should be cleared since AllowEmpty is true.
+	if doc.Language != "" {
+		t.Errorf("expected language to be cleared, got %q",
+			doc.Language)
+	}
+}
+
+func TestPruneUndeclaredDocumentType(t *testing.T) {
+	v := newTestValidator(t, simpleConstraints())
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "unknown/type",
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) == 0 {
+		t.Fatal("expected error for undeclared document type")
+	}
+
+	found := false
+
+	for _, r := range res {
+		if r.Error == `undeclared document type "unknown/type"` {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected undeclared document type error, got: %v", res)
+	}
+}
+
+func TestPruneExcessBlocksMaxCount(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/text",
+						},
+						MaxCount: intPtr(2),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"text": {},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{Type: "test/text", Data: map[string]string{"text": "first"}},
+			{Type: "test/text", Data: map[string]string{"text": "second"}},
+			{Type: "test/text", Data: map[string]string{"text": "third"}},
+			{Type: "test/text", Data: map[string]string{"text": "fourth"}},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// MaxCount=2, so only the first 2 should remain.
+	if len(doc.Content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(doc.Content))
+	}
+
+	if doc.Content[0].Data["text"] != "first" {
+		t.Errorf("expected first block, got %q", doc.Content[0].Data["text"])
+	}
+
+	if doc.Content[1].Data["text"] != "second" {
+		t.Errorf("expected second block, got %q",
+			doc.Content[1].Data["text"])
+	}
+}
+
+func TestPruneExcessBlocksCount(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Meta: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/meta",
+						},
+						Count: intPtr(1),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"key": {},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Meta: []newsdoc.Block{
+			{Type: "test/meta", Data: map[string]string{"key": "a"}},
+			{Type: "test/meta", Data: map[string]string{"key": "b"}},
+			{Type: "test/meta", Data: map[string]string{"key": "c"}},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	// Count=1, so only the first should remain.
+	if len(doc.Meta) != 1 {
+		t.Fatalf("expected 1 meta block, got %d", len(doc.Meta))
+	}
+
+	if doc.Meta[0].Data["key"] != "a" {
+		t.Errorf("expected first block, got %q", doc.Meta[0].Data["key"])
+	}
+}
+
+func TestPruneExcessAfterInvalidRemoval(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/text",
+						},
+						MaxCount: intPtr(2),
+						Data: revisor.MakeConstraintMap(
+							map[string]revisor.StringConstraint{
+								"text": {},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	// 5 blocks: 1 invalid (empty text), 4 valid. After removing the
+	// invalid one we have 4, but MaxCount=2, so excess removal trims to 2.
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{Type: "test/text", Data: map[string]string{"text": "first"}},
+			{Type: "test/text", Data: map[string]string{"text": ""}},
+			{Type: "test/text", Data: map[string]string{"text": "third"}},
+			{Type: "test/text", Data: map[string]string{"text": "fourth"}},
+			{Type: "test/text", Data: map[string]string{"text": "fifth"}},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if len(doc.Content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(doc.Content))
+	}
+
+	if doc.Content[0].Data["text"] != "first" {
+		t.Errorf("expected first block, got %q",
+			doc.Content[0].Data["text"])
+	}
+
+	if doc.Content[1].Data["text"] != "third" {
+		t.Errorf("expected third block (second valid), got %q",
+			doc.Content[1].Data["text"])
+	}
+}
+
+func TestPruneExcessNestedBlocks(t *testing.T) {
+	cs := revisor.ConstraintSet{
+		Name: "test",
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "test/article",
+				Content: []*revisor.BlockConstraint{
+					{
+						Declares: &revisor.BlockSignature{
+							Type: "test/wrapper",
+						},
+						Meta: []*revisor.BlockConstraint{
+							{
+								Declares: &revisor.BlockSignature{
+									Type: "test/tag",
+								},
+								MaxCount: intPtr(1),
+								Data: revisor.MakeConstraintMap(
+									map[string]revisor.StringConstraint{
+										"value": {},
+									},
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := newTestValidator(t, cs)
+
+	doc := &newsdoc.Document{
+		UUID: "00000000-0000-0000-0000-000000000001",
+		Type: "test/article",
+		Content: []newsdoc.Block{
+			{
+				Type: "test/wrapper",
+				Meta: []newsdoc.Block{
+					{Type: "test/tag", Data: map[string]string{"value": "keep"}},
+					{Type: "test/tag", Data: map[string]string{"value": "remove1"}},
+					{Type: "test/tag", Data: map[string]string{"value": "remove2"}},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := v.Prune(ctx, doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("expected no errors, got %d:", len(res))
+
+		for _, r := range res {
+			t.Errorf("  %v", r)
+		}
+	}
+
+	if len(doc.Content[0].Meta) != 1 {
+		t.Fatalf("expected 1 nested meta, got %d",
+			len(doc.Content[0].Meta))
+	}
+
+	if doc.Content[0].Meta[0].Data["value"] != "keep" {
+		t.Errorf("expected first tag to be kept, got %q",
+			doc.Content[0].Meta[0].Data["value"])
+	}
+}

--- a/testdata/TestPrune/constraints/core-planning.json
+++ b/testdata/TestPrune/constraints/core-planning.json
@@ -1,0 +1,220 @@
+{
+  "version": 1,
+  "name": "core-planning",
+  "documents": [
+    {
+      "name": "Planning item",
+      "description": "The planning item for an article or other deliverables",
+      "declares": "core/planning-item",
+      "links": [
+        {
+          "name": "Event",
+          "description": "The event that this planning item is coverage of, if any",
+          "declares": {
+            "rel": "event",
+            "type": "core/event"
+          },
+          "maxCount": 1,
+          "attributes": {
+            "uuid": {},
+            "title": {}
+          }
+        },
+        {
+          "ref": "core://section",
+          "count": 1
+        },
+        {
+          "ref": "core://story"
+        },
+        {
+          "name": "Category",
+          "description": "The category of the planning item",
+          "declares": {
+            "rel": "category",
+            "type": "core/category"
+          },
+          "attributes": {
+            "uuid": {},
+            "uri": { "optional": true },
+            "title": {}
+          }
+        },
+        {
+          "name": "Place",
+          "description": "The associated place for the planning item",
+          "declares": {
+            "rel": "place",
+            "type": "core/place"
+          },
+          "attributes": {
+            "uuid": {},
+            "title": {}
+          }
+        }
+      ],
+      "meta": [
+        {
+          "ref": "core://description"
+        },
+        {
+          "ref": "core://newsvalue",
+          "count": 1
+        },
+        {
+          "name": "Planning metadata",
+          "description": "Main metadata block for the planning item",
+          "declares": {
+            "type": "core/planning-item"
+          },
+          "count": 1,
+          "data": {
+            "start_date": {
+              "description": "The start date for the planning item",
+              "time": "2006-01-02"
+            },
+            "end_date": {
+              "description": "The end date for the planning item",
+              "time": "2006-01-02"
+            },
+            "date_tz": {
+              "description": "The timezone the date is in",
+              "optional": true
+            }
+          }
+        },
+        {
+          "name": "Assignment",
+          "description": "An assignment associated with the planning item",
+          "declares": {
+            "type": "core/assignment"
+          },
+          "attributes": {
+            "id": {
+              "description": "A unique identifier for the assignment",
+              "format": "uuid"
+            },
+            "title": { "allowEmpty": true }
+          },
+          "data": {
+            "full_day": {
+              "description": "Whether this is assignment is for a date rather than a specific time.",
+              "format": "bool",
+              "optional": true
+            },
+            "start": {
+              "description": "When the assignment should be carried out",
+              "format": "RFC3339",
+              "optional": true
+            },
+            "end": {
+              "description": "When work on the assignment ends.",
+              "format": "RFC3339",
+              "optional": true
+            },
+            "start_date": {
+              "description": "The start date for the assignment",
+              "time": "2006-01-02",
+              "optional": true
+            },
+            "end_date": {
+              "description": "The end date for the assignment",
+              "time": "2006-01-02",
+              "optional": true
+            },
+            "date_tz": {
+              "description": "The timezone the date is in",
+              "optional": true
+            },
+            "publish": {
+              "description": "The exact time the deliverables will be published",
+              "format": "RFC3339",
+              "optional": true
+            },
+            "public": {
+              "description": "Require the assignment to be public",
+              "format": "bool",
+              "const": "true"
+            },
+            "publish_slot": {
+              "description": "The approximate timeslot the deliverables should be published.",
+              "format": "int",
+              "optional": true
+            }
+          },
+          "meta": [
+            {
+              "name": "Assignment type",
+              "description": "Describes what kind of assignment this is",
+              "declares": {
+                "type": "core/assignment-type"
+              },
+              "minCount": 1,
+              "attributes": {
+                "value": {
+                  "enumReference": "core://assignment-types"
+                }
+              }
+            }
+          ],
+          "links": [
+            {
+              "name": "Section",
+              "description": "Section associated with the assignment",
+              "declares": {
+                "type": "core/section",
+                "rel": "section"
+              },
+              "attributes": {
+                "uuid": {},
+                "title": {}
+              }
+            },
+            {
+              "name": "Location",
+              "description": "Geographic location for the assignment",
+              "declares": {
+                "type": "core/geo-point",
+                "rel": "location"
+              },
+              "attributes": {
+                "title": {}
+              },
+              "data": {
+                "country": { "optional": true },
+                "locality": { "optional": true },
+                "name": { "optional": true },
+                "extraInfo": { "optional": true },
+                "geometry": {}
+              }
+            },
+            {
+              "name": "Deliverable",
+              "description": "A deliverable of the planning item",
+              "declares": {
+                "rel": "deliverable"
+              },
+              "attributes": {
+                "uuid": {},
+                "type": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "enums": [
+    {
+      "declare": "core://assignment-types",
+      "values": {
+        "text": {},
+        "picture": {},
+        "video": {},
+        "graphic": {},
+        "flash": {},
+        "editorial-info": {}
+      }
+    }
+  ]
+}

--- a/testdata/TestPrune/constraints/core.json
+++ b/testdata/TestPrune/constraints/core.json
@@ -1,0 +1,99 @@
+{
+  "version": 1,
+  "name": "core",
+  "meta": [
+    {
+      "id": "core://note",
+      "block": {
+        "name": "Note",
+        "description": "A public note",
+        "declares": {"type":"core/note"},
+        "attributes": {
+          "role": {"const": "public"}
+        },
+        "data": {
+          "text": {}
+        }
+      }
+    },
+    {
+      "id": "core://description",
+      "block": {
+        "name": "Description",
+        "description": "A public or internal description of the entity",
+        "declares": {"type":"core/description", "role": "public"},
+        "data": {
+          "text": {}
+        }
+      }
+    },
+    {
+      "id": "core://newsvalue",
+      "block": {
+        "name": "Newsvalue",
+        "description": "The editorial newsvalue score and lifetime",
+        "declares": {"type":"core/newsvalue"},
+        "attributes": {
+          "value": {
+            "description": "The assigned newsvalue",
+            "format": "int"
+          }
+        },
+        "data": {
+          "duration": {
+            "description": "Duration in seconds, can represent the halving time for the score in a scoring algorithm.",
+            "format":"int",
+            "optional": true
+          },
+          "end": {
+            "description": "The cut-off time that the document has no newsvalue",
+            "format":"RFC3339",
+            "optional":true
+          }
+        }
+      }
+    }
+  ],
+  "links": [
+    {
+      "id": "core://story",
+      "block": {
+        "name": "Story",
+        "description": "An ongoing story that the document relates to",
+        "declares": {"type": "core/story", "rel":"subject"},
+        "attributes": {
+          "uuid": {},
+          "title": {"allowEmpty":true}
+        }
+      }
+    },
+    {
+      "id": "core://section",
+      "block": {
+        "name": "Section",
+        "description": "The editorial section the document belongs to",
+        "declares": {"rel":"section", "type": "core/section"},
+        "attributes": {
+          "uuid": {},
+          "title": {"allowEmpty":true}
+        }
+      }
+    },
+    {
+      "id": "core://byline",
+      "block": {
+        "name": "Author byline",
+        "description": "An author credited in the byline",
+        "declares": {"type": "core/author", "rel":"author"},
+        "attributes": {
+          "uuid": {"optional":true},
+          "title": {}
+        },
+        "data": {
+          "firstName": {"optional":true},
+          "lastName": {"optional":true}
+        }
+      }
+    }
+  ]
+}

--- a/testdata/TestPrune/constraints/tt-planning.json
+++ b/testdata/TestPrune/constraints/tt-planning.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "tt-planning",
+  "documents": [
+    {
+      "match": {"type": {"const": "core/planning-item"}},
+      "meta": [
+        {
+          "ref": "tt://slugline",
+          "count": 1
+        },
+        {
+          "match": {
+            "type": {"const":"core/assignment"}
+          },
+          "meta": [
+            {
+              "ref": "tt://slugline",
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/TestPrune/constraints/tt.json
+++ b/testdata/TestPrune/constraints/tt.json
@@ -1,0 +1,200 @@
+{
+  "version": 1,
+  "name": "tt",
+  "enums": [
+    {
+      "name": "Text roles",
+      "description": "Customises allowed text roles for TT content.",
+      "match": "core://text-roles",
+      "values": {
+        "heading-3": {"forbidden":true},
+        "heading-4": {"forbidden":true},
+        "vignette": {}
+      }
+    }
+  ],
+  "documents": [
+    {
+      "name": "Category",
+      "description": "Extensions for category documents using IPTC mediatopics.",
+      "match": {"type": {"const":"core/category"}},
+      "attributes": {
+        "uri": {
+          "glob": ["iptc://mediatopic/*"]
+        }
+      },
+      "links": [
+        {
+          "name": "IPTC mediatopic",
+          "description": "Same-as link to the IPTC mediatopic identifier.",
+          "declares": {"type":"iptc/mediatopic", "rel":"same-as"},
+          "attributes": {
+            "uri": {
+              "glob": ["iptc://mediatopic/*"]
+            }
+          },
+          "data": {
+            "id": {"format":"int"}
+          }
+        }
+      ]
+    },
+    {
+      "name": "Flash",
+      "description": "Extensions for flash news documents.",
+      "match": {"type": {"const":"core/flash"}},
+      "links": [
+        {
+          "name": "Section",
+          "description": "Required section for flash documents.",
+          "match": {
+            "rel": {"const":"section"},
+            "type": {"const":"core/section"}
+          },
+          "count": 1
+        }
+      ]
+    },
+    {
+      "name": "Editorial info",
+      "description": "Extensions for editorial info documents.",
+      "match": {"type": {"const":"core/editorial-info"}},
+      "meta": [
+        {
+          "ref": "tt://slugline",
+          "count": 1
+        }
+      ],
+      "links": [
+        {
+          "name": "Section",
+          "description": "Required section for editorial info documents.",
+          "match": {
+            "rel": {"const":"section"},
+            "type": {"const":"core/section"}
+          },
+          "count": 1
+        },
+        {
+          "name": "Editorial-info type",
+          "description": "Specifies the editorial-info type",
+          "declares": {"type": "tt/editorial-info-type", "rel": "info-type"},
+          "attributes": {
+            "uuid": {}
+          }
+        }
+      ],
+      "content": [
+        {"ref": "tt://visual"}
+      ]
+    },
+    {
+      "name": "Article",
+      "description": "Extensions for article documents.",
+      "match": {"type": {"const":"core/article"}},
+      "links": [
+        {
+          "match": {
+            "type":{"const":"core/section"},
+            "rel":{"const":"section"}
+          },
+          "count": 1
+        },
+        {
+          "name": "Subtype",
+          "description": "Specifies the article subtype.",
+          "declares": {"rel":"subtype"},
+          "attributes": {
+            "uri": {"glob": ["tt://subtype/*"]}
+          }
+        },
+        {
+          "name": "Content size",
+          "description": "Specifies the content sizes we can use",
+          "match": {
+            "type": {"const":"core/content-size"}
+          },
+          "attributes": {
+            "uri": {"enum":[
+              "core://content-size/article/medium"
+            ]}
+          }
+        }
+      ],
+      "content": [
+        {"ref": "tt://visual"}
+      ],
+      "meta": [
+        {
+          "ref": "tt://slugline",
+          "count": 1
+        }
+      ]
+    }
+  ],
+  "meta": [
+    {
+      "id": "tt://slugline",
+      "block": {
+        "name": "Slugline",
+        "description": "A short keyword label used for identifying the story.",
+        "declares": {"type":"tt/slugline"},
+        "attributes": {
+          "value": {
+            "labels": ["keyword", "prefix"],
+            "hints": {"alias": ["slug"]}
+          }
+        }
+      }
+    }
+  ],
+  "content": [
+    {
+      "id": "tt://visual",
+      "block": {
+        "name": "TT visual element",
+        "description": "This can be either a picture or a graphic",
+        "declares": {"type":"tt/visual"},
+        "data": {
+          "caption": {"allowEmpty":true},
+          "html_caption": {
+            "format": "html",
+            "allowEmpty": true,
+            "optional": true
+          }
+        },
+        "meta": [
+          {"ref": "core://softcrop"}
+        ],
+        "links": [
+          {
+            "name": "Self-link",
+            "description": "Self-link pointing to the picture or graphic resource.",
+            "declares": {"rel":"self"},
+            "count": 1,
+            "attributes": {
+              "uri": {},
+              "url": {},
+              "type": {
+                "enum": ["tt/picture", "tt/graphic"]
+              }
+            },
+            "data": {
+              "credit": {"allowEmpty":true},
+              "height": {"format":"int"},
+              "width": {"format":"int"},
+              "hiresScale": {
+                "format": "float",
+                "optional": true,
+                "deprecated": {
+                  "label": "hires-scale",
+                  "doc": "Not supported anymore"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/testdata/TestPrune/documents/planning.json
+++ b/testdata/TestPrune/documents/planning.json
@@ -1,0 +1,130 @@
+{
+  "uuid": "0b27b99f-1598-4811-9861-5e410662f9f3",
+  "type": "core/planning-item",
+  "uri": "core://newscoverage/0b27b99f-1598-4811-9861-5e410662f9f3",
+  "title": " Presskonferens med Jimmie Åkesson och Linda Lindberg kl.13.30",
+  "meta": [
+    {
+      "type": "core/planning-item",
+      "data": {
+        "end_date": "2026-02-10",
+        "start_date": "2026-02-10",
+        "tentative": "false"
+      }
+    },
+    {
+      "type": "core/newsvalue",
+      "value": "4"
+    },
+    {
+      "type": "core/description",
+      "data": {
+        "text": "Sverigedemokraterna kallar till presskonferens för att presentera partiets första vallöfte inför nästa mandatperiod. Partiledare Jimmie Åkesson (SD) och gruppledare i riksdagen Linda Lindberg (SD) deltar."
+      },
+      "role": "public"
+    },
+    {
+      "type": "core/description",
+      "data": {
+        "text": "Intern info som inte ska synas."
+      },
+      "role": "internal"
+    },
+    {
+      "type": "tt/slugline",
+      "value": "sdvallöfte"
+    },
+    {
+      "id": "3450aee6-1736-4e6e-84ab-1933d1d78188",
+      "type": "core/assignment",
+      "title": "Vi bevakar",
+      "data": {
+        "end_date": "2026-02-10",
+        "full_day": "false",
+        "public": "true",
+        "publish_slot": "6",
+        "start": "2026-02-10T05:32:58.201Z",
+        "start_date": "2026-02-10"
+      },
+      "links": [
+        {
+          "uuid": "f44930d5-c71c-4bc2-93b9-68988b333522",
+          "type": "core/author",
+          "title": "Sofie Fogde",
+          "rel": "assignee",
+          "role": "primary"
+        }
+      ],
+      "meta": [
+        {
+          "type": "tt/slugline",
+          "value": "sdvallöfte"
+        },
+        {
+          "type": "core/assignment-type",
+          "value": "text"
+        }
+      ]
+    },
+    {
+      "id": "cb4e5dd1-4382-4b4a-bc30-5932d1731453",
+      "type": "core/assignment",
+      "title": "LIVE-TV Pressträff SD vallöfte KANAL 1",
+      "data": {
+        "end_date": "2026-02-10",
+        "full_day": "false",
+        "public": "true",
+        "start": "2026-02-10T12:30:00.000Z",
+        "start_date": "2026-02-10"
+      },
+      "links": [
+        {
+          "uuid": "f44930d5-c71c-4bc2-93b9-68988b333522",
+          "type": "core/author",
+          "title": "Sofie Fogde",
+          "rel": "assignee",
+          "role": "primary"
+        },
+        {
+          "uuid": "fd52d13e-f275-4fa1-97a1-c7a2ac160834",
+          "type": "core/author",
+          "title": "Henrik Montgomery",
+          "rel": "assignee",
+          "role": "primary"
+        }
+      ],
+      "meta": [
+        {
+          "type": "core/description",
+          "data": {
+            "text": "Sverigedemokraterna kallar till presskonferens för att presentera partiets första vallöfte inför nästa mandatperiod. Partiledare Jimmie Åkesson (SD) och gruppledare i riksdagen Linda Lindberg (SD) deltar.\nTid: Idag, kl 13:30.\nPlats: Riksdagens presscenter."
+          },
+          "role": "internal"
+        },
+        {
+          "type": "core/assignment-type",
+          "value": "picture"
+        },
+        {
+          "type": "core/assignment-type",
+          "value": "video"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "uuid": "248b0ddb-058e-49c1-8ab7-eee1ba3a34f7",
+      "type": "core/event",
+      "title": " Presskonferens med Jimmie Åkesson och Linda Lindberg",
+      "rel": "event"
+    },
+    {
+      "uuid": "956636ed-2687-4bc3-a45a-7e09d98c6eeb",
+      "type": "core/section",
+      "title": "Inrikes",
+      "rel": "section"
+    }
+  ],
+  "language": "sv-se"
+}

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,1 @@
+package revisor


### PR DESCRIPTION
Implement Validator.Prune() which modifies a document in-place to strip blocks that fail validation when their count constraints allow removal. Errors cascade up to the nearest removable ancestor or are reported at the document root when removal isn't possible.

Includes helper methods on BlockConstraint and DocumentConstraint for checking minimum count requirements, a comprehensive test suite, and test fixture constraint/document files for planning documents.