### PR TITLE
allow document UUIDs to be optional during validation

### DIFF
--- a/string_constraint.go
+++ b/string_constraint.go
@@ -182,9 +182,10 @@ func (sc StringConstraint) Requirement() string {
 }
 
 type ValidationContext struct {
-	coll     ValueCollector
-	depr     DeprecationHandlerFunc
-	variants []Variant
+	coll         ValueCollector
+	depr         DeprecationHandlerFunc
+	variants     []Variant
+	optionalUUID bool
 
 	ValidateHTML func(policyName, value string) error
 	ValidateEnum func(enum string, value string) (*Deprecation, error)

--- a/validation.go
+++ b/validation.go
@@ -372,6 +372,16 @@ func WithDeprecationHandler(
 	}
 }
 
+// WithOptionalDocumentUUID stops an empty document UUID from being reported as
+// a validation error. Use it for document types that are identified by
+// something other than a UUID and therefore never get one assigned. A UUID
+// that is set still has to be a valid one.
+func WithOptionalDocumentUUID() ValidationOptionFunc {
+	return func(vc *ValidationContext) {
+		vc.optionalUUID = true
+	}
+}
+
 func (v *Validator) ValidateDocument(
 	ctx context.Context,
 	document *newsdoc.Document, opts ...ValidationOptionFunc,
@@ -396,18 +406,22 @@ func (v *Validator) ValidateDocument(
 		opts[i](&vCtx)
 	}
 
-	_, err := uuid.Parse(document.UUID)
-	if err != nil {
-		res = append(res, ValidationResult{
-			Entity: []EntityRef{
-				{
-					RefType: RefTypeAttribute,
-					Name:    "uuid",
+	if document.UUID != "" || !vCtx.optionalUUID {
+		_, idErr := uuid.Parse(document.UUID)
+		if idErr != nil {
+			res = append(res, ValidationResult{
+				Entity: []EntityRef{
+					{
+						RefType: RefTypeAttribute,
+						Name:    "uuid",
+					},
 				},
-			},
-			Error: fmt.Sprintf("not a valid UUID: %v", err),
-		})
+				Error: fmt.Sprintf("not a valid UUID: %v", idErr),
+			})
+		}
 	}
+
+	var err error
 
 	for i := range v.documents {
 		match := v.documents[i].Matches(document, &vCtx)

--- a/validation_test.go
+++ b/validation_test.go
@@ -616,3 +616,82 @@ func TestTemplateDocumentType(t *testing.T) {
 		}
 	})
 }
+
+func TestOptionalDocumentUUID(t *testing.T) {
+	validator, err := revisor.NewValidator(revisor.ConstraintSet{
+		Name:    "test-uuid",
+		Version: 1,
+		Documents: []revisor.DocumentConstraint{
+			{
+				Declares: "core/article",
+				Name:     "Article",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	ctx := context.Background()
+
+	uuidResult := revisor.ValidationResult{
+		Entity: []revisor.EntityRef{
+			{
+				RefType: revisor.RefTypeAttribute,
+				Name:    "uuid",
+			},
+		},
+		Error: "not a valid UUID: invalid UUID length: 0",
+	}
+
+	t.Run("MissingUUIDIsAnError", func(t *testing.T) {
+		doc := newsdoc.Document{
+			Type: "core/article",
+		}
+
+		results, err := validator.ValidateDocument(ctx, &doc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !resultHas(results, uuidResult) {
+			t.Errorf("expected a missing UUID to be reported, got: %v", results)
+		}
+	})
+
+	t.Run("MissingUUIDCanBeAllowed", func(t *testing.T) {
+		doc := newsdoc.Document{
+			Type: "core/article",
+		}
+
+		results, err := validator.ValidateDocument(ctx, &doc,
+			revisor.WithOptionalDocumentUUID())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(results) != 0 {
+			t.Errorf("expected no validation errors, got: %v", results)
+		}
+	})
+
+	t.Run("InvalidUUIDIsStillAnError", func(t *testing.T) {
+		doc := newsdoc.Document{
+			Type: "core/article",
+			UUID: "not-a-uuid",
+		}
+
+		results, err := validator.ValidateDocument(ctx, &doc,
+			revisor.WithOptionalDocumentUUID())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !resultHas(results, revisor.ValidationResult{
+			Entity: uuidResult.Entity,
+			Error:  "not a valid UUID: invalid UUID length: 10",
+		}) {
+			t.Errorf("expected an invalid UUID to be reported, got: %v", results)
+		}
+	})
+}


### PR DESCRIPTION
Documents are normally required to carry a valid UUID. Add a WithOptionalDocumentUUID() validation option for document types that are identified by something other than a UUID and never get one assigned, so that an empty UUID stops being reported as a validation error. A UUID that is set still has to be a valid one.